### PR TITLE
Fix DNS naming | 'tox#' → 'toxdns#'

### DIFF
--- a/database.py
+++ b/database.py
@@ -47,8 +47,8 @@ class User(BASE):
     def record(self, escaped=1):
         """Return a record for this user, escaping weird bytes in
            octal format.
-           If our PIN is available, we return a tox1 record."""
-        rec = "v=tox1;id={0}{1}{2};sign={3}".format(self.public_key,
+           If our PIN is available, we return a toxdns1 record."""
+        rec = "v=toxdns1;id={0}{1}{2};sign={3}".format(self.public_key,
                                                     self.pin, self.checksum,
                                                     self.sig)
         if escaped:

--- a/dns_discovery.py
+++ b/dns_discovery.py
@@ -43,12 +43,12 @@ DISALLOWED_CHARS = set(" @/")
 # helpers
 
 REC_TRANSFORMERS = {
-    "tox1": lambda r: {
+    "toxdns1": lambda r: {
         "public_key": r["id"],
         "check": r["id"][-4:],
         "version": "Tox V1",
     },
-    "tox2": lambda r: {
+    "toxdns2": lambda r: {
         "public_key": r["pub"],
         "check": r["check"],
         "version": "Tox V2 (PIN required)",
@@ -84,7 +84,7 @@ def _lookup_key_over_dns(domain):
             values = _parse_rec("".join(txt.strings))
         except ValueError:
             continue
-        if values.get("v") != "tox" or values.get("pub") is None:
+        if values.get("v") != "toxdns" or values.get("pub") is None:
             continue
 
         try:
@@ -168,7 +168,7 @@ class DNSCore(object):
             return error_codes.ERROR_LOOKUP_FAILED
         
         if "sign" in record_data:
-            if record_data["v"] == "tox1":
+            if record_data["v"] == "toxdns1":
                 check_text = response["public_key"]
             else:
                 check_text = "".join((response["public_key"][:64],
@@ -197,7 +197,7 @@ class DNSCore(object):
                 continue
 
             v = values.get("v", None)
-            if v not in {"tox1", "tox2"}:
+            if v not in {"toxdns1", "toxdns2"}:
                 continue
 
             response = self._build_response(usr, domain, values)
@@ -259,11 +259,11 @@ class DNSCore(object):
         #        "source": SOURCE_LOCAL
         #    }
         #    if rec.is_public():
-        #        base_ret["version"] = "Tox V1 (local; public)"
+        #        base_ret["version"] = "ToxDNS V1 (local; public)"
         #        base_ret["public_key"] = (rec.public_key + rec.nospam
         #                                  + rec.checksum())
         #    else:
-        #        base_ret["version"] = "Tox V2 (local; requires PIN)"
+        #        base_ret["version"] = "ToxDNS V2 (local; requires PIN)"
         #    return cb(base_ret)
 
 def _print_answer(result):

--- a/dns_serve.py
+++ b/dns_serve.py
@@ -129,7 +129,7 @@ class ToxResolver(dnslib.server.BaseResolver):
                 if not rec:
                     reply.header.rcode = dnslib.RCODE.NXDOMAIN
                     return reply
-                base = b"v=tox3;id="
+                base = b"v=toxdns3;id="
                 if rec.pin:
                     r_payload = "{0}{1}{2}".format(rec.public_key, rec.pin,
                                                    rec.checksum)


### PR DESCRIPTION
Due to occurrences of people who were confused by 'tox#', it
is deemed necessary to rename it to 'toxdns#'.

This way people will not be confused by error messages about
'not secure tox1 protocol', which is a major improvement
when it comes to being user friendly.